### PR TITLE
fix: patch @xmldom/xmldom XML injection vulnerability (APS-18524)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^16.0.0"
   },
   "overrides": {
-    "serialize-javascript": ">=7.0.3"
+    "serialize-javascript": ">=7.0.3",
+    "@xmldom/xmldom": ">=0.9.9"
   }
 }


### PR DESCRIPTION
## Summary

- Adds npm override for `@xmldom/xmldom` >= 0.9.9 to fix **GHSA-wh4c-j3r5-mjhp** (XML injection via unsafe CDATA serialization, CVSS 7.5)
- `@xmldom/xmldom` is a transitive dev dependency (0.9.8 → 0.9.9)

## Testing

### npm audit
- `@xmldom/xmldom` vulnerability no longer appears in `npm audit` output after override applied

### BrowserStack Session Test (PASSED)
- **Build:** https://automate.browserstack.com/dashboard/v2/builds/58aadbab277bb2c4797c469984d8ce27f3847d94
- **Session:** BStack Sample Test One | **Status: PASSED** | Windows 11, Chrome 147.0 | Duration: 11s
- CodeceptJS + Playwright sample test ran successfully on BrowserStack with the override active

### Dependency verification
- `@xmldom/xmldom` resolves to 0.9.9 with the override
- All other dependencies (codeceptjs, playwright, browserstack-node-sdk) remain at same versions

## Note
`package-lock.json` is in `.gitignore` for this repo. After merging, run `npm install` to get the updated dependency resolution.

**Jira:** APS-18524

🤖 Generated with [Claude Code](https://claude.com/claude-code)