### PR TITLE
fix: patch axios SSRF vulnerability (APS-18720)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^16.0.0"
   },
   "overrides": {
-    "serialize-javascript": ">=7.0.3"
+    "serialize-javascript": ">=7.0.3",
+    "axios": ">=1.15.0"
   }
 }


### PR DESCRIPTION
## Summary

- Adds npm override for `axios` >= 1.15.0 to fix **GHSA-3p68-rc4w-qgx5** (NO_PROXY hostname normalization bypass leads to SSRF)
- `axios` is a transitive dev dependency (1.13.2 → 1.15.0)
- Axios 1.15.0 normalizes hostnames (strips trailing dots, handles IPv6 bracket notation) before evaluating NO_PROXY rules

## Testing

### npm audit
- axios SSRF vulnerability (GHSA-3p68-rc4w-qgx5) and cloud metadata exfiltration (GHSA-fvcv-3m26-pcqx) no longer appear in `npm audit` output

### BrowserStack Session Test (PASSED)
- **Build:** https://automate.browserstack.com/dashboard/v2/builds/9a938831e05f083db01205c1ce01f4a440dab0b7
- **Session:** BStack Sample Test One | **Status: PASSED** | Windows 11, Chrome 147.0 | Duration: 12s
- CodeceptJS + Playwright sample test ran successfully on BrowserStack with the override active

### Dependency verification
- `axios` resolves to 1.15.0 with the override
- All other dependencies (codeceptjs, playwright, browserstack-node-sdk) remain at same versions

## Note
`package-lock.json` is in `.gitignore` for this repo. After merging, run `npm install` to get the updated dependency resolution.

**Jira:** APS-18720

🤖 Generated with [Claude Code](https://claude.com/claude-code)