### PR TITLE
[APS-19381] fix: harden .npmrc with supply-chain security directives

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,7 @@
 package-lock=true
+ignore-scripts=true
+strict-ssl=true
+save-exact=true
+engine-strict=true
+legacy-peer-deps=false
+audit-level=high


### PR DESCRIPTION
## Security Fix: APS-19381

### Issue
The repo's `.npmrc` failed the weekly supply-chain `.npmrc` audit (SC-12282) — it only contained `package-lock=true` and was missing the required hardening directives.

### Root Cause
Missing npm hardening directives that protect against malicious lifecycle scripts, TLS downgrade, version drift, and incompatible engines.

### Fix Applied
Added the 6 required directives while preserving the existing `package-lock=true` line:
```
ignore-scripts=true
strict-ssl=true
save-exact=true
engine-strict=true
legacy-peer-deps=false
audit-level=high
```
This is a **public** repo, so `access=restricted` is intentionally omitted.

### Testing
- `npm install` succeeds (exit 0): `added 969 packages, audited 970`.
- `ignore-scripts=true` correctly skips the `postinstall` (`npm update browserstack-node-sdk`) — no native deps in this repo, so this is acceptable and the install completes cleanly.
- No `engines` field in package.json, so `engine-strict=true` has no adverse effect.

### Jira Ticket
https://browserstack.atlassian.net/browse/APS-19381

### Checklist
- [x] Security issue addressed
- [x] `npm install` validated with directives
- [ ] BrowserStack session run (N/A — config-only `.npmrc` change, no dependency/SDK changes)